### PR TITLE
Fix link to examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,11 +6,12 @@ Inspired from Kostis Kapelonis (Codefresh.io) talk at the KubeCon about [How to 
 
 ## How it works
 
-[Checkout the examples](doc/)
+[Checkout the examples](docs/examples.md)
 
 ### Kustomize example
 
 Example for Kustomization diff
+
 ```bash
 #Build base and all overlays from source branch
 goff kustomize build ./source/kustomize --output-dir /tmp/source/out
@@ -21,10 +22,10 @@ goff diff "/tmp/source" "/tmp/target" --title=Preview --output-dir .
 ```
 
 1. Create a new branch and commit your changes in your Kustomize deployment
- ![GitHub Diff](docs/img/github-diff.png)
+   ![GitHub Diff](docs/img/github-diff.png)
 2. Run your pipeline, Goff renders the Base and the Overlays and calculate the diff between the source and target branch.
 3. Check the auto generated comment in your Pull request and review the changes
- ![GitHub Diff](docs/img/goff-diff.png)
+   ![GitHub Diff](docs/img/goff-diff.png)
 
 ### ArgoCD Application
 
@@ -53,14 +54,14 @@ Use "goff [command] --help" for more information about a command.
 
 ## Supported Tools
 
-| Tooling               | Support                                       |
-|-----------------------|----------------------------------------------|
-| Plain manifests       | ✅                                          |
-| Helm                  | ✅ Supported through plain manifests        |
-| Kustomize             | ✅                                          |
-| ArgoCD Application    | ✅ Needs a local ArgoCD Repo server instance             |
-| ArgoCD ApplicationSet |  🚧 Not yet fully supported (List generators only)                |
+| Tooling               | Support                                           |
+| --------------------- | ------------------------------------------------- |
+| Plain manifests       | ✅                                                |
+| Helm                  | ✅ Supported through plain manifests              |
+| Kustomize             | ✅                                                |
+| ArgoCD Application    | ✅ Needs a local ArgoCD Repo server instance      |
+| ArgoCD ApplicationSet | 🚧 Not yet fully supported (List generators only) |
 
 ## Documentation
 
-### [Full documentation on Github pages](https://puzzle.github.io/goff) 
+### [Full documentation on Github pages](https://puzzle.github.io/goff)


### PR DESCRIPTION
This PR fixes the link to the `examples.md` in the `Readme.md`.